### PR TITLE
Implement custom command decorator and deprecate multi-version `init()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,10 @@ class ExampleComponent {
 
 main.ts:
 ```ts
-import { initV1 } from '@bedrock-oss/stylish';
+import { init } from '@bedrock-oss/stylish';
 export * from './ExampleComponent';
 
-initV1(); // Registers all decorated components on world load
-// Replace with initV2() when using Script API v2
+init(); // Registers all decorated components and wires events
 // Alternatively, you can register your own event handler and call registerAllComponents()
 
 ```

--- a/__tests__/customCommand.test.ts
+++ b/__tests__/customCommand.test.ts
@@ -1,0 +1,72 @@
+import { jest } from "@jest/globals";
+import { CommandPermissionLevel } from "@minecraft/server";
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+describe("CustomCmd decorator", () => {
+  test("registers decorated class with static run", async () => {
+    const mod = await import("../src/customCommandRegistry");
+    const { CustomCmd, registerAllCustomCommands } = mod;
+
+    @CustomCmd
+    class TestCmd {
+      readonly name = "test:hello";
+      readonly description = "Says hello";
+      readonly permissionLevel = CommandPermissionLevel.Any;
+      static run = jest.fn();
+    }
+
+    const registry = { registerCommand: jest.fn() } as any;
+    registerAllCustomCommands(registry);
+
+    expect(registry.registerCommand).toHaveBeenCalledTimes(1);
+    const [cmdInstance, runFn] = registry.registerCommand.mock.calls[0];
+    expect(cmdInstance).toBeInstanceOf(TestCmd);
+    expect(typeof runFn).toBe("function");
+
+    // Invoke run handler to ensure it proxies to static run
+    (runFn as any)();
+    expect(TestCmd.run).toHaveBeenCalled();
+  });
+
+  test("registers decorated class with instance run", async () => {
+    const mod = await import("../src/customCommandRegistry");
+    const { CustomCmd, registerAllCustomCommands } = mod;
+
+    class TestCmd2 {
+      readonly name = "test:hi";
+      readonly description = "Says hi";
+      readonly permissionLevel = CommandPermissionLevel.Any;
+      run = jest.fn();
+    }
+    CustomCmd(TestCmd2 as any);
+
+    const registry = { registerCommand: jest.fn() } as any;
+    registerAllCustomCommands(registry);
+
+    expect(registry.registerCommand).toHaveBeenCalledTimes(1);
+    const [cmdInstance, runFn] = registry.registerCommand.mock.calls[0];
+    expect(cmdInstance).toBeInstanceOf(TestCmd2 as any);
+    (runFn as any)();
+    expect((cmdInstance as any).run).toHaveBeenCalled();
+  });
+
+  test("throws when run is missing", async () => {
+    const mod = await import("../src/customCommandRegistry");
+    const { CustomCmd, registerAllCustomCommands } = mod;
+
+    class NoRun {
+      readonly name = "test:norun";
+      readonly description = "no";
+      readonly permissionLevel = CommandPermissionLevel.Any;
+    }
+    CustomCmd(NoRun as any);
+
+    const registry = { registerCommand: jest.fn() } as any;
+    expect(() => registerAllCustomCommands(registry)).toThrow(
+      /has no run method/
+    );
+  });
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -27,58 +27,52 @@ describe("registerAllComponents", () => {
   });
 });
 
-describe("initV1", () => {
-  test("subscribes to worldInitialize and registers components", () => {
+describe("init", () => {
+  test("subscribes to startup/worldLoad, registers components, and triggers events", () => {
     jest.isolateModules(() => {
-      const event = {
+      const startupEvent = {
         itemComponentRegistry: "i",
         blockComponentRegistry: "b",
       } as any;
-      const subscribe = jest.fn((cb: any) => cb(event));
+      const worldLoadEvent = { foo: "bar" } as any;
+
+      const startupSubscribe = jest.fn((cb: any) => cb(startupEvent));
+      const worldLoadSubscribe = jest.fn((cb: any) => cb(worldLoadEvent));
+
       const mc = require("@minecraft/server");
-      mc.world.beforeEvents = { worldInitialize: { subscribe } } as any;
+      mc.system.beforeEvents = { startup: { subscribe: startupSubscribe } } as any;
+      mc.world.afterEvents = { worldLoad: { subscribe: worldLoadSubscribe } } as any;
+
       const mockItems = jest.fn();
       const mockBlocks = jest.fn();
+      const mockTriggerStartup = jest.fn();
+      const mockTriggerWorldLoad = jest.fn();
+
       jest.doMock("../src/itemRegistry", () => ({
         registerAllItemComponents: mockItems,
       }));
       jest.doMock("../src/blockRegistry", () => ({
         registerAllBlockComponents: mockBlocks,
       }));
-      const index = require("../src/index");
+      jest.doMock("../src/eventRegistry", () => ({
+        triggerStartupEvent: mockTriggerStartup,
+        triggerWorldLoadEvent: mockTriggerWorldLoad,
+        OnStartup: jest.fn(),
+        OnBeforeItemUse: jest.fn(),
+        OnWorldLoad: jest.fn(),
+        RegisterEvents: jest.fn(),
+        createEventDecorator: jest.fn(),
+      }));
 
-      index.initV1();
-      expect(subscribe).toHaveBeenCalled();
+      const index = require("../src/index");
+      index.init();
+
+      expect(startupSubscribe).toHaveBeenCalled();
+      expect(worldLoadSubscribe).toHaveBeenCalled();
       expect(mockItems).toHaveBeenCalledWith("i");
       expect(mockBlocks).toHaveBeenCalledWith("b");
-    });
-  });
-});
-
-describe("initV2", () => {
-  test("subscribes to startup and registers components", () => {
-    jest.isolateModules(() => {
-      const event = {
-        itemComponentRegistry: "i",
-        blockComponentRegistry: "b",
-      } as any;
-      const subscribe = jest.fn((cb: any) => cb(event));
-      const mc = require("@minecraft/server");
-      mc.system.beforeEvents = { startup: { subscribe } } as any;
-      const mockItems = jest.fn();
-      const mockBlocks = jest.fn();
-      jest.doMock("../src/itemRegistry", () => ({
-        registerAllItemComponents: mockItems,
-      }));
-      jest.doMock("../src/blockRegistry", () => ({
-        registerAllBlockComponents: mockBlocks,
-      }));
-      const index = require("../src/index");
-
-      index.initV2();
-      expect(subscribe).toHaveBeenCalled();
-      expect(mockItems).toHaveBeenCalledWith("i");
-      expect(mockBlocks).toHaveBeenCalledWith("b");
+      expect(mockTriggerStartup).toHaveBeenCalledWith(startupEvent);
+      expect(mockTriggerWorldLoad).toHaveBeenCalledWith(worldLoadEvent);
     });
   });
 });

--- a/docs/blockcomponent.md
+++ b/docs/blockcomponent.md
@@ -15,4 +15,4 @@ class ShapeComponent {
 ```
 
 Decorated classes will be registered with the `BlockComponentRegistry` when
-`initV1()` or `initV2()` executes.
+`init()` executes.

--- a/docs/customcommand.md
+++ b/docs/customcommand.md
@@ -1,0 +1,33 @@
+# CustomCmd – Custom Command decorator
+
+Attach `@CustomCmd` to a class implementing the Minecraft `CustomCommand` shape. On startup, Stylish will instantiate and register it with the runtime's `customCommandRegistry`, wiring your `run` handler.
+
+## Example
+
+```ts
+import { CustomCmd } from "@bedrock-oss/stylish";
+import { CommandPermissionLevel, CustomCommandOrigin, CustomCommandResult, CustomCommandStatus, Player } from "@minecraft/server";
+
+@CustomCmd
+class HelloCommand {
+  // Required attributes
+  readonly name = "example:hello";
+  readonly description = "Greets the command source";
+  readonly permissionLevel = CommandPermissionLevel.Any;
+  // Optional attributes
+  readonly cheatsRequired = false;
+
+  // You can use either a static or instance `run` method
+  static run(origin: CustomCommandOrigin): CustomCommandResult {
+    const { sourceEntity } = origin;
+    if (sourceEntity instanceof Player) {
+      sourceEntity.sendMessage(`Hello, ${sourceEntity.name}`);
+      return { status: CustomCommandStatus.Success };
+    }
+    return { status: CustomCommandStatus.Failure };
+  }
+}
+```
+
+Decorated classes will be registered with the `CustomCommandRegistry` when
+`init()` executes.

--- a/docs/itemcomponent.md
+++ b/docs/itemcomponent.md
@@ -16,5 +16,5 @@ class CooldownComponent {
 }
 ```
 
-When `initV1()` or `initV2()` runs, every class decorated with `ItemComponent`
-will be registered with the appropriate `ItemComponentRegistry`.
+When `init()` runs, every class decorated with `ItemComponent` will be
+registered with the appropriate `ItemComponentRegistry`.

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -2,6 +2,12 @@ import { RawMessage } from "@minecraft/server";
 
 jest.mock('@minecraft/server', () => {
   return {
+    CommandPermissionLevel: {
+      Any: 0,
+      GameMasters: 1,
+      Admin: 2,
+      Owner: 3,
+    },
     Direction: {
       Down: 'Down',
       East: 'East',

--- a/src/customCommandRegistry.ts
+++ b/src/customCommandRegistry.ts
@@ -1,0 +1,49 @@
+import type {
+  CustomCommand,
+  CustomCommandRegistry,
+} from "@minecraft/server";
+import { registerInstanceEventHandlers } from "./eventRegistry";
+
+
+/**
+ * Constructor type for Custom Commands. Constructors must not have parameters.
+ */
+export type CustomCommandCtor = new () => CustomCommand & Record<string, any>;
+
+
+const registry: CustomCommandCtor[] = [];
+
+/**
+ * Decorator – attach to each Custom Command class to auto-register it.
+ */
+export function CustomCmd<T extends CustomCommandCtor>(ctor: T) {
+  registry.push(ctor);
+}
+
+/**
+ * Call this in worldInitialize to register all decorated components.
+ */
+export function registerAllCustomCommands(
+  customCommandRegistry: CustomCommandRegistry
+) {
+  for (const Ctor of registry) {
+    const instance = new Ctor();
+    registerInstanceEventHandlers(instance);
+
+    let runFn: ((...args: any[]) => any) | undefined;
+    const maybeStaticRun = (Ctor as any).run;
+    if (typeof maybeStaticRun === "function") {
+      runFn = maybeStaticRun.bind(Ctor);
+    } else if (typeof (instance as any).run === "function") {
+      runFn = (instance as any).run.bind(instance);
+    }
+
+    if (!runFn) {
+      throw new Error(
+        `Custom command ${Ctor.name} has no run method. Define a static or instance run(origin, ...args).`
+      );
+    }
+
+    customCommandRegistry.registerCommand(instance as any, runFn as any);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,22 @@ export function init() {
 }
 
 /**
+ * Registers V1 `worldInitialize` event and registers all components.
+ * @deprecated Use {@link init() `init()`} instead. **Please note that Minecraft Script API v1.X is no longer supported and this will initialize for Minecraft Script API V2.X and later!**
+ */
+export function initV1() {
+    init();
+}
+
+/**
+ * Registers V1 `worldInitialize` event and registers all components.
+ * @deprecated Use {@link init() `init()`} instead.
+ */
+export function initV2() {
+    init();
+}
+
+/**
  * Registers all components.
  * @param itemRegistry Item component registry
  * @param blockRegistry Block component registry

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@ import { BlockComponentRegistry, ItemComponentRegistry, StartupEvent, system, wo
 import { registerAllItemComponents } from "./itemRegistry";
 import { registerAllBlockComponents } from "./blockRegistry";
 import { triggerStartupEvent, triggerWorldLoadEvent } from "./eventRegistry";
+import { registerAllCustomCommands } from "./customCommandRegistry";
 
 export { BindThis } from "./autobind";
 export { ItemComponent } from "./itemRegistry";
 export { BlockComponent } from "./blockRegistry";
 export { OnStartup, OnBeforeItemUse, OnWorldLoad, RegisterEvents, createEventDecorator } from "./eventRegistry";
+export { CustomCmd } from "./customCommandRegistry";
 
 /**
  * Initializes the library
@@ -14,6 +16,7 @@ export { OnStartup, OnBeforeItemUse, OnWorldLoad, RegisterEvents, createEventDec
 export function init() {
     system.beforeEvents.startup.subscribe((e: StartupEvent) => {
         registerAllComponents(e.itemComponentRegistry, e.blockComponentRegistry);
+        registerAllCustomCommands(e.customCommandRegistry);
         triggerStartupEvent(e);
     });
     world.afterEvents.worldLoad.subscribe((e: WorldLoadAfterEvent) => {


### PR DESCRIPTION
## e2ad30a
This commit aims to rectify the following issues:
1. Test suite fails because `initV1()` and `initV2()` are no longer exported, and has been removed entirely. This commit aims to rectify this by changing the tests to use the unified `init()`, and;
2. Docs were not updated to reflect the removal of `initV1()` and `initV2()`.

With the deprecation and removal of these functions, the following has been done consequently in this commit:
- removed `initV1()`, then;
- `initV2()` has been renamed to `init()`.
In other words, in favor of new 2.X Scripts API version, `initV1()` has been removed entirely.

Moreover, the addition of event decorators in commit faec67b provided more requirement in pushing things to Script API v2.X.

## b734363
Added the `@CustomCmd` decorator for registering custom commands.